### PR TITLE
[RFC] Improved semantics by using empty array as default

### DIFF
--- a/ramp-for-gutenberg.php
+++ b/ramp-for-gutenberg.php
@@ -33,13 +33,13 @@ include __DIR__ . '/inc/admin/class-ramp-for-gutenberg-post-type-settings-ui.php
 * `ramp_for_gutenberg_load_gutenberg` must be called in the theme before `admin_init`, normally from functions.php or the like
 *
 */
-function ramp_for_gutenberg_load_gutenberg( $criteria = false ) {
+function ramp_for_gutenberg_load_gutenberg( $criteria = array() ) {
 	// prevent the front-end from interacting with this plugin at all
 	if ( !is_admin() ) {
 		return;
 	}
 	$RFG = Ramp_For_Gutenberg::get_instance();
-	$criteria = ( !$criteria ) ? [ 'load' => 1 ] : $criteria;
+	$criteria = empty( $criteria ) || ! is_array( $criteria ) ? [ 'load' => 1 ] : $criteria;
 	$stored_criteria = $RFG->get_criteria();
 	if ( $criteria !== $stored_criteria ) {
 		// the criteria specified in code have changed -- update them


### PR DESCRIPTION
Per https://github.com/Automattic/ramp-for-gutenberg/issues/38, this could improve dev experience by making criteria always an array. Updating @mikeselander's original examples

`wpcom_vip_load_gutenberg( true )` - loads, invalid array, default used
`wpcom_vip_load_gutenberg( false );` - loads, invalid array, default used
`wpcom_vip_load_gutenberg( [ 'load' => 1 ] );` - loads, matches default

Regarding the last case where `['load' => true]` is passed, it looks like that value gets stripped in sanitization: https://github.com/Automattic/ramp-for-gutenberg/blob/master/inc/class-ramp-for-gutenberg.php#L159