### PR TITLE
Issue 33 allow multiple calls to rfg

### DIFF
--- a/inc/class-gutenberg-ramp-criteria.php
+++ b/inc/class-gutenberg-ramp-criteria.php
@@ -101,7 +101,12 @@ class Gutenberg_Ramp_Criteria {
 
 		$merged_criteria = [];
 
-		// This kind of works - If 'load' is set, it gets transformed into an array when it should just be an integer
+		// Remove any previous value for `load`. It should only ever be an integer, and does not need to be merged with existing values for `load`.
+		if( isset( $criteria['load'] && isset( $existing_criteria['load'] ) ) ) {
+			unset( $existing_criteria['load'] );
+		}
+
+		// Merge the new criteria with the existing criteria.
 		$merged_criteria = array_merge_recursive( $criteria, $existing_criteria );
 
 		// Clear out duplicate values.
@@ -109,11 +114,6 @@ class Gutenberg_Ramp_Criteria {
 			if ( is_array( $value ) ) {
 				$merged_criteria[ $key ] = array_unique( $value );
 			}
-		}
-
-		// If 'load' is set, transform it back into an integer (whatever the most recent passed value for 'load')
-		if ( isset( $merged_criteria['load'] ) && is_array( $merged_criteria['load'] ) && ! empty( $merged_criteria['load'] ) ) {
-			$merged_criteria['load'] = $merged_criteria['load'][0];
 		}
 
 		return $merged_criteria;

--- a/inc/class-gutenberg-ramp-criteria.php
+++ b/inc/class-gutenberg-ramp-criteria.php
@@ -82,6 +82,7 @@ class Gutenberg_Ramp_Criteria {
 
 	/**
 	 * Merge all criteria from all calls to ramp_for_gutenberg_load_gutenberg()
+	 * New criteria takes precedence over existing criteria.
 	 *
 	 * @param array $criteria The new criteria to be merged with existing criteria.
 	 * @param array $existing_criteria Any existing criteria to be merged.

--- a/inc/class-gutenberg-ramp-criteria.php
+++ b/inc/class-gutenberg-ramp-criteria.php
@@ -101,7 +101,7 @@ class Gutenberg_Ramp_Criteria {
 		}
 
 		// Remove any previous value for `load`. It should only ever be an integer, and does not need to be merged with existing values for `load`.
-		if( isset( $criteria['load'] && isset( $existing_criteria['load'] ) ) ) {
+		if( isset( $criteria['load'] ) && isset( $existing_criteria['load'] ) ) {
 			unset( $existing_criteria['load'] );
 		}
 

--- a/inc/class-gutenberg-ramp-criteria.php
+++ b/inc/class-gutenberg-ramp-criteria.php
@@ -100,8 +100,6 @@ class Gutenberg_Ramp_Criteria {
 			return $existing_criteria;
 		}
 
-		$merged_criteria = [];
-
 		// Remove any previous value for `load`. It should only ever be an integer, and does not need to be merged with existing values for `load`.
 		if( isset( $criteria['load'] && isset( $existing_criteria['load'] ) ) ) {
 			unset( $existing_criteria['load'] );


### PR DESCRIPTION
#33 

**Change to allow multiple calls to `ramp_for_gutenberg_load_gutenberg()`**

Allows multiple function calls to `ramp_for_gutenberg_load_gutenberg()` and merges the criteria before saving to the database. Works by storing each set of criteria in a class variable, merging as they come in and then saves to the database during `admin_init`.

The last value for `load` that is passed into `ramp_for_gutenberg_load_gutenberg()` will be the one that's used. This means that while `post_ids` and `post_types` values will be merged, any call to `ramp_for_gutenberg_load_gutenberg()` using the `load` parameter will override anything set in `post_ids` or `post_types`.