### PR TITLE
Create a dedicated criteria class

### DIFF
--- a/gutenberg-ramp.php
+++ b/gutenberg-ramp.php
@@ -22,6 +22,7 @@
 */
 
 include __DIR__ . '/inc/class-gutenberg-ramp.php';
+include __DIR__ . '/inc/class-gutenberg-ramp-criteria.php';
 include __DIR__ . '/inc/admin/class-gutenberg-ramp-post-type-settings-ui.php';
 
 /**

--- a/gutenberg-ramp.php
+++ b/gutenberg-ramp.php
@@ -51,11 +51,11 @@ function gutenberg_ramp_load_gutenberg( $criteria = true ) {
 		$criteria['load'] = (int) $criteria['load'];
 	}
 
-	$stored_criteria = $gutenberg_ramp->get_criteria();
+	$stored_criteria = $gutenberg_ramp->criteria->get();
 
 	if ( $criteria !== $stored_criteria ) {
 		// the criteria specified in code have changed -- update them
-		$gutenberg_ramp->set_criteria( $criteria );
+		$gutenberg_ramp->criteria->set( $criteria );
 	}
 	// indicate that we've loaded the plugin. 
 	$gutenberg_ramp->active = true;

--- a/inc/admin/class-gutenberg-ramp-post-type-settings-ui.php
+++ b/inc/admin/class-gutenberg-ramp-post-type-settings-ui.php
@@ -76,7 +76,7 @@ class Gutenberg_Ramp_Post_Type_Settings_UI {
 		 * Even though `disabled` attribute prevents data from being submitted to server
 		 * This is just going to make sure it accidentally doesn't fall through
 		 */
-		$helper_enabled_post_types = (array) $this->gutenberg_ramp->get_criteria( 'post_types' );
+		$helper_enabled_post_types = (array) $this->gutenberg_ramp->criteria->get( 'post_types' );
 		$validated_post_types      = array_diff( $validated_post_types, $helper_enabled_post_types );
 
 		return $validated_post_types;
@@ -88,8 +88,8 @@ class Gutenberg_Ramp_Post_Type_Settings_UI {
 	function render_settings_section() {
 
 		$post_types                = $this->gutenberg_ramp->get_supported_post_types();
-		$helper_enabled_post_types = (array) $this->gutenberg_ramp->get_criteria( 'post_types' );
-		$enabled_post_types        = $this->gutenberg_ramp->get_enabled_post_types();
+		$helper_enabled_post_types = (array) $this->gutenberg_ramp->criteria->get( 'post_types' );
+		$enabled_post_types        = $this->gutenberg_ramp->criteria->get_enabled_post_types();
 		?>
 		<div class="gutenberg-ramp-description">
 			<p>
@@ -151,6 +151,8 @@ class Gutenberg_Ramp_Post_Type_Settings_UI {
 		</div>
 		<?php
 	}
+
+
 
 
 }

--- a/inc/class-gutenberg-ramp-criteria.php
+++ b/inc/class-gutenberg-ramp-criteria.php
@@ -171,8 +171,10 @@ class Gutenberg_Ramp_Criteria {
 		return true;
 	}
 
-
-	public function purge() {
+	/**
+	 * Delete the criteria data from options
+	 */
+	public function delete() {
 		delete_option( $this->get_option_name() );
 	}
 

--- a/inc/class-gutenberg-ramp-criteria.php
+++ b/inc/class-gutenberg-ramp-criteria.php
@@ -1,0 +1,193 @@
+<?php
+
+class Gutenberg_Ramp_Criteria {
+
+	/**
+	 * Criteria is temporarily stored on class instance before it can be validated and updated
+	 * Do not trust raw data stored in $criteria!
+	 * @var mixed null|array
+	 */
+	private static $criteria = null;
+
+	/**
+	 * Where the Gutenberg Ramp criteria is stored in opitons
+	 * @var string
+	 */
+	private $option_name    = 'gutenberg_ramp_load_critera';
+
+	/**
+	 * Gutenberg_Ramp_Criteria constructor.
+	 */
+	public function __construct() {
+		$this->option_name = apply_filters( 'gutenberg_ramp_option_name', $this->option_name );
+	}
+
+	/**
+	 * Get the option name
+	 *
+	 * @return string
+	 */
+	public function get_option_name() {
+
+		return $this->option_name;
+	}
+
+	/**
+	 * Get the desired criteria
+	 *
+	 * @param string $criteria_name - post_types, post_ids, load
+	 *
+	 * @return mixed
+	 */
+	public function get( $criteria_name = '' ) {
+
+		$options = get_option( $this->get_option_name() );
+
+		if ( '' === $criteria_name ) {
+			return $options;
+		}
+
+		if ( empty( $options[ $criteria_name ] ) ) {
+			return false;
+		}
+
+		return $options[ $criteria_name ];
+
+	}
+
+	/**
+	 * Set the private class variable $criteria
+	 * self::$criteria going to be used to update the option when `$this->save_criteria()` is run
+	 *
+	 * @param $criteria
+	 *
+	 * @return bool
+	 */
+	public function set( $criteria ) {
+
+		if ( $this->is_sanitized( $criteria ) ) {
+			self::$criteria = $criteria;
+
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Save criteria in WordPres options if it's valid
+	 */
+	public function save() {
+
+		if ( null !== self::$criteria && $this->is_valid( self::$criteria ) ) {
+			update_option( $this->get_option_name(), self::$criteria );
+		}
+
+	}
+
+	/**
+	 * Make sure that the passed $post_types exist and can support Gutenberg
+	 *
+	 * @param array $post_types
+	 *
+	 * @return bool
+	 */
+	public function validate_post_types( $post_types ) {
+
+		$ramp = Gutenberg_Ramp::get_instance();
+		$supported_post_types = array_keys( $ramp->get_supported_post_types() );
+
+		foreach ( (array) $post_types as $post_type ) {
+			if ( ! in_array( $post_type, $supported_post_types, true ) ) {
+				_doing_it_wrong( 'gutenberg_ramp_load_gutenberg', "Cannot enable Gutenberg support for post type \"{$post_type}\"", null );
+
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Validate $criteria
+	 * This will make sure that the passed $criteria can actually support Gutenberg
+	 *
+	 * @param $criteria
+	 *
+	 * @return bool
+	 */
+	public function is_valid( $criteria ) {
+
+		if ( ! empty( $criteria['post_types'] ) && ! $this->validate_post_types( $criteria['post_types'] ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Sanitize $criteria by making sure it's formatted properly
+	 *
+	 * @param $criteria
+	 *
+	 * @return bool
+	 */
+	public function is_sanitized( $criteria ) {
+
+		if ( ! is_array( $criteria ) || ! $criteria ) {
+			return false;
+		}
+
+		$criteria_whitelist = [ 'post_ids', 'post_types', 'load' ];
+		foreach ( $criteria as $key => $value ) {
+			if ( ! in_array( $key, $criteria_whitelist, true ) ) {
+				return false;
+			}
+			switch ( $key ) {
+				case 'post_ids':
+					foreach ( $value as $id ) {
+						if ( ! ( is_numeric( $id ) && $id > 0 ) ) {
+							return false;
+						}
+					}
+					break;
+				case 'post_types':
+					foreach ( $value as $post_type ) {
+						if ( sanitize_title( $post_type ) !== $post_type ) {
+							return false;
+						}
+					}
+					break;
+				case 'load':
+					if ( ! in_array( $value, [ 0, 1 ], true ) ) {
+						return false;
+					}
+					break;
+				default:
+					break;
+			}
+		}
+
+		return true;
+	}
+
+
+	public function purge() {
+		delete_option( $this->get_option_name() );
+	}
+
+	/**
+	 * Get all post types with Gutenberg enabled
+	 *
+	 * @return array
+	 */
+	public function get_enabled_post_types() {
+
+		$ui_enabled_post_types     = (array) get_option( 'gutenberg_ramp_post_types', [] );
+		$helper_enabled_post_types = (array) $this->get( 'post_types' );
+
+		return array_unique( array_merge( $ui_enabled_post_types, $helper_enabled_post_types ) );
+
+	}
+}
+

--- a/inc/class-gutenberg-ramp-criteria.php
+++ b/inc/class-gutenberg-ramp-criteria.php
@@ -109,7 +109,6 @@ class Gutenberg_Ramp_Criteria {
 	}
 
 	/**
-	 * Validate $criteria
 	 * This will make sure that the passed $criteria can actually support Gutenberg
 	 *
 	 * @param $criteria
@@ -126,7 +125,7 @@ class Gutenberg_Ramp_Criteria {
 	}
 
 	/**
-	 * Sanitize $criteria by making sure it's formatted properly
+	 * Check whether $criteria is sanitized or not
 	 *
 	 * @param $criteria
 	 *

--- a/inc/class-gutenberg-ramp.php
+++ b/inc/class-gutenberg-ramp.php
@@ -309,7 +309,7 @@ class Gutenberg_Ramp {
 		}
 		// if the theme did not call its function, then remove the option containing criteria, which will prevent all loading
 		if ( ! $this->active ) {
-			$this->criteria->purge();
+			$this->criteria->delete();
 		}
 	}
 

--- a/inc/class-gutenberg-ramp.php
+++ b/inc/class-gutenberg-ramp.php
@@ -107,7 +107,7 @@ class Gutenberg_Ramp {
 		 * Return false early -
 		 * If criteria is empty and there are no post types enabled from the Ramp UI
 		 */
-		if ( ! $criteria && empty( $this->get_enabled_post_types() ) ) {
+		if ( ! $criteria && empty( $this->criteria->get_enabled_post_types() ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
This PR relies on #49 - that should be merged before this PR is reviewed.

While cleaning up everything in #49,
I noticed that `Gutenberg_Ramp` had `{CRUD}_criteria` methods - which is a good sign that Criteria should be a module itself. 

This PR extracts the criteria related functionality to `Gutenberg_Ramp_Criteria` - I think it makes the code easier to navigate. 

No logic changes included.