### PR TITLE
Unsupported post types notice

### DIFF
--- a/inc/admin/class-gutenberg-ramp-post-type-settings-ui.php
+++ b/inc/admin/class-gutenberg-ramp-post-type-settings-ui.php
@@ -90,6 +90,7 @@ class Gutenberg_Ramp_Post_Type_Settings_UI {
 		$post_types                = $this->gutenberg_ramp->get_supported_post_types();
 		$helper_enabled_post_types = (array) $this->gutenberg_ramp->criteria->get( 'post_types' );
 		$enabled_post_types        = $this->gutenberg_ramp->criteria->get_enabled_post_types();
+		$unsupported_post_types    = $this->gutenberg_ramp->get_unsupported_post_types();
 		?>
 		<div class="gutenberg-ramp-description">
 			<p>
@@ -139,6 +140,20 @@ class Gutenberg_Ramp_Post_Type_Settings_UI {
 			</tr>
 			</tbody>
 		</table>
+
+		<?php if ( ! empty( $unsupported_post_types ) ): ?>
+			<div class="gutenberg-ramp-unsupported-post-types" style="padding: .44rem 1.22rem; background-color: rgba(255, 255, 255, .5); max-width: 720px; border-left: solid 4px #0073aa;">
+				<p>
+					<?php esc_html_e( "The following post types were found, but are not be compatible with Gutenberg:", 'gutenberg-ramp' )?>
+					<code>
+						<?php echo esc_html( implode( ', ', $unsupported_post_types ) ) ?>
+					</code>
+				</p>
+				<p>
+					<a href="https://github.com/Automattic/gutenberg-ramp#faqs" target="_blank"><?php esc_html_e( 'Learn More', 'gutenberg-ramp' )  ?></a>
+				</p>
+			</div>
+		<?php endif; ?>
 
 		<div class="gutenberg-ramp-description">
 			<p>

--- a/inc/class-gutenberg-ramp.php
+++ b/inc/class-gutenberg-ramp.php
@@ -385,4 +385,26 @@ class Gutenberg_Ramp {
 	}
 
 
+	/**
+	 * Get a list of unsupported post types post types
+	 * @return array
+	 */
+	public function get_unsupported_post_types() {
+
+		if ( 0 === did_action( 'init' ) && ! doing_action( 'init' ) ) {
+			_doing_it_wrong( 'Gutenberg_Ramp::get_supported_post_types', "get_supported_post_types() was called before the init hook. Some post types might not be registered yet.", '1.0.0' );
+		}
+
+		$post_types       = array_keys( get_post_types( [
+				'public'   => true,  // Remove any internal/hidden post types
+				'_builtin' => false, // Remove builtin post types like attachment, revision, etc.
+			]
+		) );
+		
+		$supported_post_types = array_keys( $this->get_supported_post_types() );
+
+		return array_diff( $post_types, $supported_post_types );
+	}
+
+
 }

--- a/inc/class-gutenberg-ramp.php
+++ b/inc/class-gutenberg-ramp.php
@@ -392,7 +392,7 @@ class Gutenberg_Ramp {
 	public function get_unsupported_post_types() {
 
 		if ( 0 === did_action( 'init' ) && ! doing_action( 'init' ) ) {
-			_doing_it_wrong( 'Gutenberg_Ramp::get_supported_post_types', "get_supported_post_types() was called before the init hook. Some post types might not be registered yet.", '1.0.0' );
+			_doing_it_wrong( 'Gutenberg_Ramp::get_unsupported_post_types', "get_unsupported_post_types() was called before the init hook. Some post types might not be registered yet.", '1.1.0' );
 		}
 
 		$post_types       = array_keys( get_post_types( [
@@ -400,7 +400,7 @@ class Gutenberg_Ramp {
 				'_builtin' => false, // Remove builtin post types like attachment, revision, etc.
 			]
 		) );
-		
+
 		$supported_post_types = array_keys( $this->get_supported_post_types() );
 
 		return array_diff( $post_types, $supported_post_types );


### PR DESCRIPTION
Fixes #56 by adding a notice letting users know that post type has been found but isn't supported by Gutenberg. 

Not all post types are expected to be visible in the dashboard, which is why I decided to use `get_post_types('public'   => true);` as the criteria for "all post types". I think that showing notices only for `public` should cover most if not all of the false positives.

![screen shot 2018-06-20 at 4 14 06 pm](https://user-images.githubusercontent.com/988095/41660558-0bb33f94-74a5-11e8-9d97-a4484abd6864.png)
