### PR TITLE
Removed autoloading ramp options for other admin pages

### DIFF
--- a/inc/class-gutenberg-ramp-criteria.php
+++ b/inc/class-gutenberg-ramp-criteria.php
@@ -41,6 +41,12 @@ class Gutenberg_Ramp_Criteria {
 	 */
 	public function get( $criteria_name = '' ) {
 
+		global $pagenow;
+
+		if ( 'posts-new.php' !== $pagenow || 'edit.php' !== $pagenow ) {
+			return;
+		}
+		
 		$options = get_option( $this->get_option_name() );
 
 		if ( '' === $criteria_name ) {


### PR DESCRIPTION
Hi Team,

I have removed the autoloading ramp options for other admin pages.

issue #63 

Please review it and let me know if any changes on that.

Thanks,
Chetan