### PR TITLE
Lower plugins_loaded hook priority so gutenberg can load meta boxes

### DIFF
--- a/inc/class-gutenberg-ramp.php
+++ b/inc/class-gutenberg-ramp.php
@@ -35,7 +35,7 @@ class Gutenberg_Ramp {
 		$this->criteria = new Gutenberg_Ramp_Criteria();
 
 		// Load/Unload/Ignore Gutenberg:
-		add_action( 'plugins_loaded', [ $this, 'load_decision' ], 20, 0 );
+		add_action( 'plugins_loaded', [ $this, 'load_decision' ], 5, 0 );
 
 
 		/**


### PR DESCRIPTION
The current priority `20` is greater than the default priority of `10` from https://github.com/WordPress/gutenberg/blob/master/lib/register.php#L27

Before this change meta boxes weren't getting added as `gutenberg_trick_plugins_into_registering_meta_boxes` would never get called.