### PR TITLE
Prepare for WordPress 5.0

### DIFF
--- a/gutenberg-ramp.php
+++ b/gutenberg-ramp.php
@@ -130,7 +130,7 @@ function gutenberg_ramp_require_gutenberg() {
 	do_action( 'gutenberg_ramp_before_load_gutenberg' );
 	$gutenberg_include = apply_filters( 'gutenberg_ramp_gutenberg_load_path', WP_PLUGIN_DIR . '/gutenberg/gutenberg.php' );
 
-	if ( validate_file( $gutenberg_include ) !== 0 ) {
+	if ( false === $gutenberg_include || 0 !== validate_file( $gutenberg_include ) ) {
 		return false;
 	}
 	// flag this for the filter

--- a/gutenberg-ramp.php
+++ b/gutenberg-ramp.php
@@ -154,6 +154,6 @@ $gutenberg_ramp = Gutenberg_Ramp::get_instance();
  * Tell Gutenberg when not to load:
  */
 // Gutenberg >= 3.5
-add_filter( 'gutenberg_can_edit_post', [ $gutenberg_ramp, 'maybe_load_gutenberg' ], 20, 2 );
+add_filter( 'gutenberg_can_edit_post', [ $gutenberg_ramp, 'maybe_load_gutenberg' ], 10, 2 );
 // WordPress >= 5.0
-add_filter( 'use_block_editor_for_post', [ $gutenberg_ramp, 'maybe_load_gutenberg' ], 20, 2 );
+add_filter( 'use_block_editor_for_post', [ $gutenberg_ramp, 'maybe_load_gutenberg' ], 10, 2 );

--- a/gutenberg-ramp.php
+++ b/gutenberg-ramp.php
@@ -111,6 +111,39 @@ function ramp_for_gutenberg_load_gutenberg( $criteria = false ) {
 	gutenberg_ramp_load_gutenberg( $criteria );
 }
 
+/**
+ * Ramp expects Gutenberg to be active
+ * This function is going to load Gutenberg plugin if it's not already active
+ *
+ * @return bool
+ */
+function gutenberg_ramp_require_gutenberg() {
+
+	if ( function_exists( 'gutenberg_init' ) ) {
+		return false;
+	}
+
+	// perform any actions required before loading gutenberg
+	do_action( 'gutenberg_ramp_before_load_gutenberg' );
+	$gutenberg_include = apply_filters( 'gutenberg_ramp_gutenberg_load_path', WP_PLUGIN_DIR . '/gutenberg/gutenberg.php' );
+
+	if ( validate_file( $gutenberg_include ) !== 0 ) {
+		return false;
+	}
+	// flag this for the filter
+	if ( file_exists( $gutenberg_include ) ) {
+		include_once $gutenberg_include;
+		return true;
+	}
+
+	return false;
+
+}
+
+/**
+ * Rquire Gutenberg
+ */
+gutenberg_ramp_require_gutenberg();
 
 /**
  * Initialize Gutenberg Ramp instantly

--- a/gutenberg-ramp.php
+++ b/gutenberg-ramp.php
@@ -119,10 +119,11 @@ function ramp_for_gutenberg_load_gutenberg( $criteria = false ) {
  */
 function gutenberg_ramp_require_gutenberg() {
 
-	// @TODO: Check for a function like `use_block_editor_for_post` to determine if is 5.0+
-	// ( make sure to use a function that always exists in 5.0+, even out of Admin area )
-
-	if ( function_exists( 'gutenberg_init' ) ) {
+	/**
+	 * `register_block_type` exists in both Gutenberg and WordPress 5.0
+	 * If the function already exists - don't manually include Gutenberg Plugin
+	 */
+	if ( function_exists( 'register_block_type' ) ) {
 		return false;
 	}
 

--- a/gutenberg-ramp.php
+++ b/gutenberg-ramp.php
@@ -131,16 +131,15 @@ function gutenberg_ramp_require_gutenberg() {
 	do_action( 'gutenberg_ramp_before_load_gutenberg' );
 	$gutenberg_include = apply_filters( 'gutenberg_ramp_gutenberg_load_path', WP_PLUGIN_DIR . '/gutenberg/gutenberg.php' );
 
-	if ( false === $gutenberg_include || 0 !== validate_file( $gutenberg_include ) ) {
+	if (    false === $gutenberg_include
+		||  0 !== validate_file( $gutenberg_include )
+		||  ! file_exists( $gutenberg_include )
+	) {
 		return false;
 	}
-	// flag this for the filter
-	if ( file_exists( $gutenberg_include ) ) {
-		include_once $gutenberg_include;
-		return true;
-	}
 
-	return false;
+	include_once $gutenberg_include;
+	return true;
 
 }
 

--- a/gutenberg-ramp.php
+++ b/gutenberg-ramp.php
@@ -119,6 +119,9 @@ function ramp_for_gutenberg_load_gutenberg( $criteria = false ) {
  */
 function gutenberg_ramp_require_gutenberg() {
 
+	// @TODO: Check for a function like `use_block_editor_for_post` to determine if is 5.0+
+	// ( make sure to use a function that always exists in 5.0+, even out of Admin area )
+
 	if ( function_exists( 'gutenberg_init' ) ) {
 		return false;
 	}

--- a/gutenberg-ramp.php
+++ b/gutenberg-ramp.php
@@ -141,11 +141,19 @@ function gutenberg_ramp_require_gutenberg() {
 }
 
 /**
- * Rquire Gutenberg
+ * Rquire Gutenberg Plugin
  */
 gutenberg_ramp_require_gutenberg();
 
 /**
- * Initialize Gutenberg Ramp instantly
+ * Initialize Gutenberg Ramp
  */
-Gutenberg_Ramp::get_instance();
+$gutenberg_ramp = Gutenberg_Ramp::get_instance();
+
+/**
+ * Tell Gutenberg when not to load:
+ */
+// Gutenberg >= 3.5
+add_filter( 'gutenberg_can_edit_post', [ $gutenberg_ramp, 'maybe_load_gutenberg' ], 20, 2 );
+// WordPress >= 5.0
+add_filter( 'use_block_editor_for_post', [ $gutenberg_ramp, 'maybe_load_gutenberg' ], 20, 2 );

--- a/gutenberg-ramp.php
+++ b/gutenberg-ramp.php
@@ -4,7 +4,7 @@
  *
  * Plugin Name: Gutenberg Ramp
  * Description: Allows theme authors to control the circumstances under which the Gutenberg editor loads. Options include "load" (1 loads all the time, 0 loads never) "post_ids" (load for particular posts) "post_types" (load for particular posts types.)
- * Version:     1.0.0
+ * Version:     1.1.0-rc.1
  * Author:      Automattic, Inc.
  * License:     GPL-2.0+
  * License URI: http://www.gnu.org/licenses/old-licenses/gpl-2.0.html

--- a/inc/class-gutenberg-ramp-criteria.php
+++ b/inc/class-gutenberg-ramp-criteria.php
@@ -15,11 +15,15 @@ class Gutenberg_Ramp_Criteria {
 	 *
 	 * @param string $criteria_name - post_types, post_ids, load
 	 *
-	 * @return mixed
+	 * @return mixed Return the values on success, false on failure
 	 */
 	public function get( $criteria_name = '' ) {
 
 		$options = self::$criteria;
+
+		if ( null === $options ) {
+			return false;
+		}
 
 		if ( '' === $criteria_name ) {
 			return $options;

--- a/inc/class-gutenberg-ramp-criteria.php
+++ b/inc/class-gutenberg-ramp-criteria.php
@@ -136,7 +136,6 @@ class Gutenberg_Ramp_Criteria {
 		return true;
 	}
 
-
 	/**
 	 * Get all post types with Gutenberg enabled
 	 *
@@ -145,10 +144,13 @@ class Gutenberg_Ramp_Criteria {
 	public function get_enabled_post_types() {
 
 		$ui_enabled_post_types     = (array) get_option( 'gutenberg_ramp_post_types', [] );
-		$helper_enabled_post_types = (array) $this->get( 'post_types' );
+		$helper_enabled_post_types = $this->get( 'post_types' );
+
+		if ( false === $helper_enabled_post_types || ! is_array( $helper_enabled_post_types ) ) {
+			return $ui_enabled_post_types;
+		}
 
 		return array_unique( array_merge( $ui_enabled_post_types, $helper_enabled_post_types ) );
-
 	}
 }
 

--- a/inc/class-gutenberg-ramp-criteria.php
+++ b/inc/class-gutenberg-ramp-criteria.php
@@ -29,12 +29,11 @@ class Gutenberg_Ramp_Criteria {
 			return $options;
 		}
 
-		if ( empty( $options[ $criteria_name ] ) ) {
-			return false;
+		if ( isset( $options[ $criteria_name ] ) ) {
+			return $options[ $criteria_name ];
 		}
 
-		return $options[ $criteria_name ];
-
+		return false;
 	}
 
 	/**

--- a/inc/class-gutenberg-ramp-criteria.php
+++ b/inc/class-gutenberg-ramp-criteria.php
@@ -9,28 +9,6 @@ class Gutenberg_Ramp_Criteria {
 	 */
 	private static $criteria = null;
 
-	/**
-	 * Where the Gutenberg Ramp criteria is stored in opitons
-	 * @var string
-	 */
-	private $option_name    = 'gutenberg_ramp_load_critera';
-
-	/**
-	 * Gutenberg_Ramp_Criteria constructor.
-	 */
-	public function __construct() {
-		$this->option_name = apply_filters( 'gutenberg_ramp_option_name', $this->option_name );
-	}
-
-	/**
-	 * Get the option name
-	 *
-	 * @return string
-	 */
-	public function get_option_name() {
-
-		return $this->option_name;
-	}
 
 	/**
 	 * Get the desired criteria
@@ -41,7 +19,7 @@ class Gutenberg_Ramp_Criteria {
 	 */
 	public function get( $criteria_name = '' ) {
 
-		$options = get_option( $this->get_option_name() );
+		$options = self::$criteria;
 
 		if ( '' === $criteria_name ) {
 			return $options;
@@ -57,7 +35,6 @@ class Gutenberg_Ramp_Criteria {
 
 	/**
 	 * Set the private class variable $criteria
-	 * self::$criteria going to be used to update the option when `$this->save_criteria()` is run
 	 *
 	 * @param $criteria
 	 *
@@ -72,17 +49,6 @@ class Gutenberg_Ramp_Criteria {
 		}
 
 		return false;
-	}
-
-	/**
-	 * Save criteria in WordPres options if it's valid
-	 */
-	public function save() {
-
-		if ( null !== self::$criteria && $this->is_valid( self::$criteria ) ) {
-			update_option( $this->get_option_name(), self::$criteria );
-		}
-
 	}
 
 	/**
@@ -170,12 +136,6 @@ class Gutenberg_Ramp_Criteria {
 		return true;
 	}
 
-	/**
-	 * Delete the criteria data from options
-	 */
-	public function delete() {
-		delete_option( $this->get_option_name() );
-	}
 
 	/**
 	 * Get all post types with Gutenberg enabled

--- a/inc/class-gutenberg-ramp.php
+++ b/inc/class-gutenberg-ramp.php
@@ -30,17 +30,6 @@ class Gutenberg_Ramp {
 	private function __construct() {
 
 		$this->criteria = new Gutenberg_Ramp_Criteria();
-
-		/**
-		 * Tell Gutenberg when not to load
-		 *
-		 * Gutenberg only calls this filter when checking the primary post
-		 */
-		// Gutenberg < 4.1
-		add_filter( 'gutenberg_can_edit_post', [ $this, 'maybe_load_gutenberg' ], 20, 2 );
-
-		// WordPress > 5.0
-		add_filter( 'use_block_editor_for_post', [ $this, 'maybe_load_gutenberg' ], 20, 2 );
 	}
 
 	/**
@@ -173,7 +162,6 @@ class Gutenberg_Ramp {
 		return $available_post_types;
 	}
 
-
 	/**
 	 * Get a list of unsupported post types post types
 	 * @return array
@@ -194,6 +182,5 @@ class Gutenberg_Ramp {
 
 		return array_diff( $post_types, $supported_post_types );
 	}
-
 
 }

--- a/inc/class-gutenberg-ramp.php
+++ b/inc/class-gutenberg-ramp.php
@@ -32,14 +32,6 @@ class Gutenberg_Ramp {
 		$this->criteria = new Gutenberg_Ramp_Criteria();
 
 		/**
-		 * If gutenberg_ramp_load_gutenberg() has not been called, perform cleanup
-		 * unfortunately this must be done on every admin pageload to detect the case where
-		 * criteria were previously being set in a theme, but now are not (due to a code change)
-		 */
-		add_action( 'admin_init', [ $this, 'cleanup_option' ], 10, 0 );
-
-
-		/**
 		 * Tell Gutenberg when not to load
 		 *
 		 * Gutenberg only calls this filter when checking the primary post
@@ -192,21 +184,6 @@ class Gutenberg_Ramp {
 		}
 
 		return false;
-	}
-
-	/**
-	 * Remove the stored Gutenberg Ramp settings if `gutenberg_ramp()` isn't used
-	 */
-	public function cleanup_option() {
-
-		// if the criteria are already such that Gutenberg will never load, no change is needed
-		if ( $this->criteria->get() === [ 'load' => 0 ] ) {
-			return;
-		}
-		// if the theme did not call its function, then remove the option containing criteria, which will prevent all loading
-		if ( ! $this->active ) {
-			$this->criteria->delete();
-		}
 	}
 
 	/**

--- a/inc/class-gutenberg-ramp.php
+++ b/inc/class-gutenberg-ramp.php
@@ -35,9 +35,12 @@ class Gutenberg_Ramp {
 		 * Tell Gutenberg when not to load
 		 *
 		 * Gutenberg only calls this filter when checking the primary post
-		 * @TODO duplicate this for WP5.0 core with the new filter name, it's expected to change
 		 */
+		// Gutenberg < 4.1
 		add_filter( 'gutenberg_can_edit_post', [ $this, 'gutenberg_should_load' ], 20, 2 );
+
+		// WordPress > 5.0
+		add_filter( 'use_block_editor_for_post', [ $this, 'gutenberg_should_load' ], 20, 2 );
 	}
 
 

--- a/inc/class-gutenberg-ramp.php
+++ b/inc/class-gutenberg-ramp.php
@@ -159,36 +159,6 @@ class Gutenberg_Ramp {
 
 	}
 
-	/**
-	 * Check whether Gutenberg is already being loaded
-	 *
-	 * @return bool
-	 */
-	public function gutenberg_will_load() {
-
-		// for WordPress version >= 5, Gutenberg will load
-		global $wp_version;
-		$version_arr     = explode( '.', $wp_version );
-		$wp_version_main = (int) $version_arr[0];
-		if ( $wp_version_main >= 5 ) {
-			return true;
-		}
-
-
-		// also, the gutenberg plugin might be the source of an attempted load
-		if (
-			has_filter( 'replace_editor', 'gutenberg_init' )
-			||
-			has_filter( 'load-post.php', 'gutenberg_intercept_edit_post' )
-			||
-			has_filter( 'load-post-new.php', 'gutenberg_intercept_post_new' )
-		) {
-			return true;
-		}
-
-		return false;
-	}
-
 	//
 	//
 	// ----- Utility functions -----

--- a/inc/class-gutenberg-ramp.php
+++ b/inc/class-gutenberg-ramp.php
@@ -114,20 +114,7 @@ class Gutenberg_Ramp {
 			return false;
 		}
 
-		// Find the current post type
-		$current_post_type = false;
-		if ( 0 === (int) $post_id ) {
-
-			if ( isset( $_GET['post_type'] ) ) {
-				$current_post_type = sanitize_title( $_GET['post_type'] );
-			} // Regular posts are plain `post-new.php` with no `post_type` parameter defined.
-			elseif ( $this->is_eligible_admin_url( [ 'post-new.php' ] ) ) {
-				$current_post_type = 'post';
-			}
-
-		} else {
-			$current_post_type = get_post_type( $post_id );
-		}
+		$current_post_type = get_post_type( $post_id );
 
 		// Exit if no current post type found
 		if ( false === $current_post_type ) {
@@ -143,28 +130,6 @@ class Gutenberg_Ramp {
 	// ----- Utility functions -----
 	//
 	//
-
-	/**
-	 * Check if the current URL is elegible for Gutenberg
-	 *
-	 * @param array $supported_filenames - which /wp-admin/ pages to check for. Defaults to `post.php` and `post-new.php`
-	 * @return bool
-	 */
-	public function is_eligible_admin_url( $supported_filenames = [ 'post.php', 'post-new.php' ] ) {
-
-		$path          = sanitize_text_field( wp_parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH ) );
-		$path          = trim( $path );
-		$wp_admin_slug = trim( wp_parse_url( get_admin_url(), PHP_URL_PATH ), '/' );
-
-		foreach ( $supported_filenames as $filename ) {
-			// Require $filename not to be empty to avoid accidents like matching against a plain `/wp-admin/`
-			if ( ! empty( $filename ) && "/{$wp_admin_slug}/{$filename}" === $path ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
 
 	/**
 	 * Get post types that can be supported by Gutenberg.

--- a/inc/class-gutenberg-ramp.php
+++ b/inc/class-gutenberg-ramp.php
@@ -54,7 +54,7 @@ class Gutenberg_Ramp {
 		}
 
 		// check if we should always or never load
-		if ( false !== $criteria && array_key_exists( 'load', $criteria ) ) {
+		if ( false !== $this->criteria->get( 'load' ) ) {
 			if ( $criteria['load'] === 1 ) {
 				return true;
 			} elseif ( $criteria['load'] === 0 ) {

--- a/inc/class-gutenberg-ramp.php
+++ b/inc/class-gutenberg-ramp.php
@@ -82,22 +82,22 @@ class Gutenberg_Ramp {
 		// in order load Gutnberg because of other criteria, we will need to check that a few things are true:
 		// 1. we are attempting to load post.php ... there's an available post_id
 		// 2. there's an available post_id in the URL to check
-		$gutenberg_ramp_post_id = $this->get_current_post_id();
+		$current_post_id = $this->get_current_post_id();
 
 		// check post_types
-		if ( $this->is_allowed_post_type( $gutenberg_ramp_post_id ) ) {
+		if ( $this->is_allowed_post_type( $current_post_id ) ) {
 			return true;
 		}
 
-		if ( ! $gutenberg_ramp_post_id ) {
+		if ( ! $current_post_id ) {
 			return false;
 		}
 
 		// grab the criteria
-		$gutenberg_ramp_post_ids = ( isset( $criteria['post_ids'] ) ) ? $criteria['post_ids'] : [];
+		$ramp_post_ids = ( isset( $criteria['post_ids'] ) ) ? $criteria['post_ids'] : [];
 
 		// check post_ids
-		if ( in_array( $gutenberg_ramp_post_id, $gutenberg_ramp_post_ids, true ) ) {
+		if ( in_array( $current_post_id, $ramp_post_ids, true ) ) {
 			return true;
 		}
 	}

--- a/inc/class-gutenberg-ramp.php
+++ b/inc/class-gutenberg-ramp.php
@@ -37,30 +37,24 @@ class Gutenberg_Ramp {
 		 * Gutenberg only calls this filter when checking the primary post
 		 */
 		// Gutenberg < 4.1
-		add_filter( 'gutenberg_can_edit_post', [ $this, 'gutenberg_should_load' ], 20, 2 );
+		add_filter( 'gutenberg_can_edit_post', [ $this, 'maybe_load_gutenberg' ], 20, 2 );
 
 		// WordPress > 5.0
-		add_filter( 'use_block_editor_for_post', [ $this, 'gutenberg_should_load' ], 20, 2 );
+		add_filter( 'use_block_editor_for_post', [ $this, 'maybe_load_gutenberg' ], 20, 2 );
 	}
 
-
 	/**
-	 * Figure out whether or not Gutenberg should be loaded
+	 * Figure out whether or not Gutenberg should be loaded for the given post
 	 *
-	 * Ramp has everything disabled by default, so the default answer  for `gutenberg_should_load` is false
+	 * Ramp has everything disabled by default, so the default answer for `gutenberg_should_load` is false
 	 * The conditions in the functions are attempts to change that to true
 	 *
 	 * @return bool
 	 *
 	 */
-	public function gutenberg_should_load( $can_edit, $post ) {
+	public function gutenberg_should_load( $post ) {
 
-		// Don't load the Gutenberg, if the Gutenberg doesn't want to be loaded
-		if( false === $can_edit ) {
-			return false;
-		}
-
- 		$criteria = $this->criteria->get();
+		$criteria = $this->criteria->get();
 
 		/**
 		 * Return false early -
@@ -87,7 +81,6 @@ class Gutenberg_Ramp {
 			return true;
 		}
 
-
 		$ramp_post_ids = ( isset( $criteria['post_ids'] ) ) ? $criteria['post_ids'] : [];
 		if ( in_array( $post->ID, $ramp_post_ids, true ) ) {
 			return true;
@@ -96,7 +89,16 @@ class Gutenberg_Ramp {
 		return false;
 	}
 
+	public function maybe_load_gutenberg( $can_edit, $post ) {
 
+		// Don't load the Gutenberg, if the Gutenberg doesn't want to be loaded
+		if ( false === $can_edit ) {
+			return false;
+		}
+
+		return $this->gutenberg_should_load( $post );
+
+	}
 
 	/**
 	 * Check whether current post type is defined as gutenberg-friendly

--- a/inc/class-gutenberg-ramp.php
+++ b/inc/class-gutenberg-ramp.php
@@ -38,13 +38,6 @@ class Gutenberg_Ramp {
 		 */
 		add_action( 'admin_init', [ $this, 'cleanup_option' ], 10, 0 );
 
-		/**
-		 * Store the criteria on admin_init
-		 *
-		 * $priority = 5 to ensure that the UI class has fresh data available
-		 * To do that, we need this to run before `gutenberg_ramp_initialize_admin_ui()`
-		 */
-		add_action( 'admin_init', [ $this->criteria, 'save' ], 5, 0 );
 
 		/**
 		 * Tell Gutenberg when not to load

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Gutenberg Ramp ===
 Contributors: automattic, mattoperry, justnorris, enigmaweb
 Tags: gutenberg, ramp, classic editor, legacy editor, gutenberg ramp
-Requires at least: 4.9.6
-Tested up to: 4.9.6
+Requires at least: 4.9.8
+Tested up to: 4.9.8
 Requires PHP: 5.5
 Stable tag: 1.0.0
 License: GPLv2 or later


### PR DESCRIPTION
This PR prepares Ramp for the WordPress 5.0 release. I tried to be descriptive in each of the commit message titles and comments - please review each separately for a more detailed view.

To summarize - 
This is Gutenberg Ramp 1.1-rc.1 - a lot of stuff is removed for compatibility with WordPress 5.0 and beyond. Some important decisions were made along the way:

* Ramp is prepared to no longer make the **load** decision. Instead - it defers to Gutenberg ( and Block Editor in 5.0 ) filters to make an **unload** decision when necessary *(Ramp is still unloading by default even if the Ramp function isn't called)*

* Ramp now checks for `register_block_type` to determine whether or not Gutenberg is active. `register_block_type` is used both in Gutenberg plugin and in WordPress Core 5.0+

* Ramp is no longer making the load decision, but it is including Gutenberg plugin directly if necessary. Previously Gutenberg Plugin [was included directly](https://github.com/Automattic/gutenberg-ramp/blob/d7d353aafda9c89f9669add9828800b87621d760/inc/class-gutenberg-ramp.php#L78) through `include` only if the Ramp function was used. This has now changed and is going to try to manually include `gutenberg/gutenberg.php` if `register_block_type` function does not exist. - This is to bring 4.9.8 Gutenberg behavior closer to 5.0.0 - Ramp now tries to assume Gutenberg is always turned on.

* Ramp is no longer using WordPress options to cache the load decisions because the load decisions happen after `after_setup_theme` - so themes and plugins can now call the ramp loading function and see the effects instantly. Previously the values were cached in options because Ramp was making the decision in the middle of `plugins_init` which was inaccessible for themes and plugins with name starting a letter after *G*.

* Removed quite a few methods from classes that were not necessary anymore.

_p.s. Along the way I cleaned up a PHP Warning, a few variable names and moved adding filters out of the `Gutenberg_Ramp` class constructor to make the code a bit more object-oriented. I know that it's sub-optimal, but to move faster I decided to make those changes on the fly instead of making separate PRs that depend on this one_ 