### PR TITLE
Add a notice when requirements aren’t met

### DIFF
--- a/gutenberg-ramp.php
+++ b/gutenberg-ramp.php
@@ -115,7 +115,7 @@ function ramp_for_gutenberg_load_gutenberg( $criteria = false ) {
 /**
  * @return bool|string
  */
-function gutenberg_ramp_validated_gutenberg_load_path() {
+function gutenberg_ramp_get_validated_gutenberg_load_path() {
 
 	$gutenberg_plugin_path = apply_filters( 'gutenberg_ramp_gutenberg_load_path', WP_PLUGIN_DIR . '/gutenberg/gutenberg.php' );
 
@@ -148,7 +148,7 @@ function gutenberg_ramp_require_gutenberg() {
 	// perform any actions required before loading gutenberg
 	do_action( 'gutenberg_ramp_before_load_gutenberg' );
 
-	$validated_load_path = gutenberg_ramp_validated_gutenberg_load_path();
+	$validated_load_path = gutenberg_ramp_get_validated_gutenberg_load_path();
 	if ( false !== $validated_load_path ) {
 		include_once $validated_load_path;
 	}

--- a/gutenberg-ramp.php
+++ b/gutenberg-ramp.php
@@ -24,6 +24,7 @@
 include __DIR__ . '/inc/class-gutenberg-ramp.php';
 include __DIR__ . '/inc/class-gutenberg-ramp-criteria.php';
 include __DIR__ . '/inc/admin/class-gutenberg-ramp-post-type-settings-ui.php';
+include __DIR__ . '/inc/admin/class-gutenberg-ramp-compatibility-check.php';
 
 /**
  * This function allows themes to specify Gutenberg loading critera.
@@ -112,6 +113,23 @@ function ramp_for_gutenberg_load_gutenberg( $criteria = false ) {
 }
 
 /**
+ * @return bool|string
+ */
+function gutenberg_ramp_validated_gutenberg_load_path() {
+
+	$gutenberg_plugin_path = apply_filters( 'gutenberg_ramp_gutenberg_load_path', WP_PLUGIN_DIR . '/gutenberg/gutenberg.php' );
+
+	if ( empty( $gutenberg_plugin_path )
+	     || 0 !== validate_file( $gutenberg_plugin_path )
+	     || ! file_exists( $gutenberg_plugin_path )
+	) {
+		return false;
+	}
+
+	return $gutenberg_plugin_path;
+}
+
+/**
  * Ramp expects Gutenberg to be active
  * This function is going to load Gutenberg plugin if it's not already active
  *
@@ -129,16 +147,12 @@ function gutenberg_ramp_require_gutenberg() {
 
 	// perform any actions required before loading gutenberg
 	do_action( 'gutenberg_ramp_before_load_gutenberg' );
-	$gutenberg_include = apply_filters( 'gutenberg_ramp_gutenberg_load_path', WP_PLUGIN_DIR . '/gutenberg/gutenberg.php' );
 
-	if (    false === $gutenberg_include
-		||  0 !== validate_file( $gutenberg_include )
-		||  ! file_exists( $gutenberg_include )
-	) {
-		return false;
+	$validated_load_path = gutenberg_ramp_validated_gutenberg_load_path();
+	if ( false !== $validated_load_path ) {
+		include_once $validated_load_path;
 	}
 
-	include_once $gutenberg_include;
 	return true;
 
 }
@@ -147,6 +161,11 @@ function gutenberg_ramp_require_gutenberg() {
  * Rquire Gutenberg Plugin
  */
 gutenberg_ramp_require_gutenberg();
+
+if ( Gutenberg_Ramp_Compatibility_Check::should_check_compatibility() ) {
+	$ramp_compatibility = new Gutenberg_Ramp_Compatibility_Check();
+	add_action( 'admin_init', [ $ramp_compatibility, 'maybe_display_notice' ] );
+}
 
 /**
  * Initialize Gutenberg Ramp

--- a/gutenberg-ramp.php
+++ b/gutenberg-ramp.php
@@ -158,7 +158,7 @@ function gutenberg_ramp_require_gutenberg() {
 }
 
 /**
- * Rquire Gutenberg Plugin
+ * Require Gutenberg Plugin
  */
 gutenberg_ramp_require_gutenberg();
 

--- a/inc/admin/class-gutenberg-ramp-compatibility-check.php
+++ b/inc/admin/class-gutenberg-ramp-compatibility-check.php
@@ -1,0 +1,73 @@
+<?php
+
+class Gutenberg_Ramp_Compatibility_Check {
+
+	/**
+	 * Gutenberg Compatibility should only be checked in WordPress < 5.0,
+	 * because Core 5.0 and Gutenberg Plugin < 4.1.0 are not compatible anyway,
+	 * and Gutenberg_Ramp_Compatibility_Check is only needed to check for Gutenberg Plugin < 3.5.0
+	 */
+	public static function should_check_compatibility() {
+
+		return apply_filters( 'gutenberg_ramp_should_check_compatibility', version_compare( $GLOBALS['wp_version'], '5.0', '<' ) );
+	}
+
+	public static function should_display_message() {
+
+		$gutenberg_version = static::get_gutenberg_version();
+
+		/**
+		 * If no Gutenberg version is found, don't display a notice
+		 * Because this class only cares about a specific condition ( GB < 3.5 )
+		 */
+		if ( false === $gutenberg_version ) {
+			return false;
+		}
+
+		return version_compare( $gutenberg_version, '3.5', '<' );
+	}
+
+	public static function get_gutenberg_version() {
+
+		$gutenberg_plugin_path = gutenberg_ramp_validated_gutenberg_load_path();
+		if ( false === $gutenberg_plugin_path ) {
+			return false;
+		}
+
+		$gutenberg_data = get_plugin_data( $gutenberg_plugin_path, false, false );
+
+		if ( empty( $gutenberg_data['Version'] ) ) {
+			return false;
+		}
+
+		return $gutenberg_data['Version'];
+	}
+
+
+	// The backup sanity check, in case the plugin is activated in a weird way,
+	// or the versions change after activation.
+	public function maybe_display_notice() {
+
+		if ( self::should_display_message() ) {
+			add_action( 'admin_notices', [ $this, 'display_notice' ] );
+		}
+	}
+
+	public function display_notice() {
+
+		?>
+		<div class="notice notice-error is-dismissible">
+			<p>
+				<strong> <?php esc_html_e( 'Gutenberg Ramp functionality is disabled' ); ?></strong> <br/>
+				<?php if ( current_time( 'timestamp' ) > 1542672000 ): // November 20th, 2018 ?>
+					<?php esc_html_e( 'Gutenberg Ramp is no longer controlling where Gutenberg is loaded. Please update Gutenberg to at least version 3.5 or update to WordPress 5.0 to restore Gutenberg Ramp functionality.', 'gutenberg-ramp' ) ?>
+				<?php else: ?>
+					<?php esc_html_e( 'Gutenberg Ramp is no longer controlling where Gutenberg is loaded. Please update Gutenberg to at least version 3.5 to restore Gutenberg Ramp functionality.', 'gutenberg-ramp' ) ?>
+				<?php endif; ?>
+			</p>
+		</div>
+		<?php
+
+	}
+}
+

--- a/inc/admin/class-gutenberg-ramp-compatibility-check.php
+++ b/inc/admin/class-gutenberg-ramp-compatibility-check.php
@@ -29,7 +29,7 @@ class Gutenberg_Ramp_Compatibility_Check {
 
 	public static function get_gutenberg_version() {
 
-		$gutenberg_plugin_path = gutenberg_ramp_validated_gutenberg_load_path();
+		$gutenberg_plugin_path = gutenberg_ramp_get_validated_gutenberg_load_path();
 		if ( false === $gutenberg_plugin_path ) {
 			return false;
 		}

--- a/inc/admin/class-gutenberg-ramp-compatibility-check.php
+++ b/inc/admin/class-gutenberg-ramp-compatibility-check.php
@@ -59,11 +59,7 @@ class Gutenberg_Ramp_Compatibility_Check {
 		<div class="notice notice-error is-dismissible">
 			<p>
 				<strong> <?php esc_html_e( 'Gutenberg Ramp functionality is disabled' ); ?></strong> <br/>
-				<?php if ( current_time( 'timestamp' ) > 1542672000 ): // November 20th, 2018 ?>
-					<?php esc_html_e( 'Gutenberg Ramp is no longer controlling where Gutenberg is loaded. Please update Gutenberg to at least version 3.5 or update to WordPress 5.0 to restore Gutenberg Ramp functionality.', 'gutenberg-ramp' ) ?>
-				<?php else: ?>
-					<?php esc_html_e( 'Gutenberg Ramp is no longer controlling where Gutenberg is loaded. Please update Gutenberg to at least version 3.5 to restore Gutenberg Ramp functionality.', 'gutenberg-ramp' ) ?>
-				<?php endif; ?>
+				<?php esc_html_e( 'The version of Gutenberg you have installed is not compatible with Gutenberg Ramp. To restore Ramp functionality, please upgrade to Gutenberg 4.1 (or newer) or WordPress 5.0 (or newer).', 'gutenberg-ramp' ) ?>
 			</p>
 		</div>
 		<?php


### PR DESCRIPTION
This adds a notice in WordPress < 5.0 if Gutenberg is also below version 3.5.0 because Ramp doesn’t work with Gutenberg plugin that old anymore.

This is what the notice looks like:

![screen shot 2018-11-01 at 5 47 34 pm](https://user-images.githubusercontent.com/988095/47863280-94f0ad00-ddff-11e8-80bb-06d56f5749e9.png)

<s>The notice is a bit hacky in that it changes based on date. Anything after November 20, 2018 will append "Or upgrade to WordPress 5.0" in the notice based on a timestamp. An available WordPress update could be checked with `wp_version_check()` but I think it just adds too much overhead for such a small edge case that I opted for the simplest solution here, even though it may not be perfectly accurate. Let me know if you think the notice should rely on `wp_version_check()` instead or even be worded differently.</s> There's only 1 type of notice now when the PR is updated 🎉 

This PR also extracts code from `gutenberg_ramp_require_gutenberg()` into a new function: `gutenberg_ramp_validated_gutenberg_load_path` - this is because `apply_filters()` is used and the Gutenberg path can be modified, so instead of manually applying filters twice - I've moved the filter to a dedicated function.