### PR TITLE
Call _deprecated_function() for plugin, admin notice

### DIFF
--- a/gutenberg-ramp.php
+++ b/gutenberg-ramp.php
@@ -196,7 +196,7 @@ function gutenberg_ramp_admin_notice() {
 		<p><?php 
 			printf(
 				esc_html__(
-					'Gutenberg Ramp is deprecated and should be replaced by filters. See %shere%s for more information.',
+					'Gutenberg Ramp is deprecated and should be replaced by filters. See %sdocumentation%s for more information.',
 					'gutenberg-ramp' 
 				),
 				sprintf(

--- a/gutenberg-ramp.php
+++ b/gutenberg-ramp.php
@@ -191,6 +191,16 @@ function gutenberg_ramp_admin_notice() {
 		return;
 	}
 
+	$is_vip_env = ( ( defined( 'WPCOM_IS_VIP_ENV' ) ) && ( true === WPCOM_IS_VIP_ENV ) );
+
+	if ( $is_vip_env ) {
+		$notice_url = 'https://lobby.vip.wordpress.com/2020/11/23/removing-gutenberg-ramp/';
+	}
+
+	else {
+		$notice_url = 'https://developer.wordpress.org/reference/hooks/use_block_editor_for_post/';
+	}
+
 	?>
 	<div class="notice notice-success is-dismissible">
 		<p><?php 
@@ -201,9 +211,7 @@ function gutenberg_ramp_admin_notice() {
 				),
 				sprintf(
 					'<a href="%s" target="_new">',
-					esc_url(
-						'https://developer.wordpress.org/reference/hooks/use_block_editor_for_post/'
-					)
+					esc_url( $notice_url )
 				),
 				'</a>'
 			); ?>

--- a/gutenberg-ramp.php
+++ b/gutenberg-ramp.php
@@ -170,6 +170,51 @@ if ( Gutenberg_Ramp_Compatibility_Check::should_check_compatibility() ) {
 }
 
 /**
+ * Display notice about plugin being obsolete.
+ */
+function gutenberg_ramp_admin_notice() {
+	/*
+	 * Only display when user can manage
+	 * options, i.e. only to admins.
+	 */
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return;
+	}
+
+	$gutenberg_ramp = Gutenberg_Ramp::get_instance();
+
+	/*
+	 * Do not display if the plugin is
+	 * not loaded.
+	 */
+	if ( false === $gutenberg_ramp->active ) {
+		return;
+	}
+
+	?>
+	<div class="notice notice-success is-dismissible">
+		<p><?php 
+			printf(
+				esc_html__(
+					'Gutenberg Ramp is deprecated and should be replaced by filters. See %shere%s for more information.',
+					'gutenberg-ramp' 
+				),
+				sprintf(
+					'<a href="%s" target="_new">',
+					esc_url(
+						'https://developer.wordpress.org/reference/hooks/use_block_editor_for_post/'
+					)
+				),
+				'</a>'
+			); ?>
+		</p>
+	</div>
+	<?php
+}
+
+add_action( 'admin_notices', 'gutenberg_ramp_admin_notice' );
+
+/**
  * Initialize Gutenberg Ramp
  */
 $gutenberg_ramp = Gutenberg_Ramp::get_instance();

--- a/gutenberg-ramp.php
+++ b/gutenberg-ramp.php
@@ -39,6 +39,8 @@ include __DIR__ . '/inc/admin/class-gutenberg-ramp-compatibility-check.php';
  */
 function gutenberg_ramp_load_gutenberg( $criteria = true ) {
 
+	_deprecated_function( 'gutenberg_ramp_load_gutenberg', '0.3', ' built-in filters instead. See https://developer.wordpress.org/reference/hooks/use_block_editor_for_post/ for more information' );
+
 	// only admin requests should refresh loading behavior
 	if ( ! is_admin() ) {
 		return;

--- a/gutenberg-ramp.php
+++ b/gutenberg-ramp.php
@@ -207,7 +207,7 @@ function gutenberg_ramp_admin_notice() {
 		<p><?php 
 			printf(
 				esc_html__(
-					'Gutenberg Ramp is deprecated and should be replaced by filters. See %sdocumentation%s for more information.',
+					'The Gutenberg Ramp plugin is deprecated and your installation may require some changes. Please read %sour documentation%s for more information.',
 					'gutenberg-ramp' 
 				),
 				sprintf(


### PR DESCRIPTION
Plugin is obsolete and is being phased out. Let users know that they should use a filter instead.

This patch will make a notice display with a link to more information, and also invokes a deprecation function.