### PR TITLE
Add alert in case of use on VIP Go

### DIFF
--- a/gutenberg-ramp.php
+++ b/gutenberg-ramp.php
@@ -50,13 +50,11 @@ function gutenberg_ramp_load_gutenberg( $criteria = true ) {
 		( rand( 0, 99 ) === 50 ) &&
 		( function_exists( 'wpcom_vip_irc' ) )
 	) {
-		global $wpdb;
-
 		wpcom_vip_irc(
 			'#vip-gutenberg-ramp-deprecation',
 			sprintf(
 				'Site with ID %d is still using Gutenberg Ramp plugin (via %s())',
-				(int) $wpdb->blogid,
+				VIP_GO_APP_ID,
 				__FUNCTION__
 			),
 			0 // Lowest priority

--- a/gutenberg-ramp.php
+++ b/gutenberg-ramp.php
@@ -42,6 +42,27 @@ function gutenberg_ramp_load_gutenberg( $criteria = true ) {
 	// Ignore the awkward phrasing in the 3rd param; we're skipping the word "Use" because core already adds that.
 	_deprecated_function( 'gutenberg_ramp_load_gutenberg', '0.3', ' built-in filters instead. See https://developer.wordpress.org/reference/hooks/use_block_editor_for_post/ for more information' );
 
+	// If on VIP Go, and with only 1% of calls, alert
+	// VIP that someone is still using the plugin
+	if (
+		( defined( 'WPCOM_IS_VIP_ENV' ) ) &&
+		( true === WPCOM_IS_VIP_ENV ) &&
+		( rand( 0, 99 ) === 50 ) &&
+		( function_exists( 'wpcom_vip_irc' ) )
+	) {
+		global $wpdb;
+
+		wpcom_vip_irc(
+			'#vip-gutenberg-ramp-deprecation',
+			sprintf(
+				'Site with ID %d is still using Gutenberg Ramp plugin (via %s())',
+				(int) $wpdb->blogid,
+				__FUNCTION__
+			),
+			0 // Lowest priority
+		);
+	}
+
 	// only admin requests should refresh loading behavior
 	if ( ! is_admin() ) {
 		return;


### PR DESCRIPTION
As a part of deprecation of Gutenberg Ramp, we want to be alerted if `gutenberg_ramp_load_gutenberg()` is being called on the VIP Go platform. Here we accomplish this by adding an alert, but only if using VIP Go and only with 1% of calls.